### PR TITLE
Switch to HTML link for flatbush

### DIFF
--- a/content/posts/literate-flatbush.mdx
+++ b/content/posts/literate-flatbush.mdx
@@ -11,7 +11,7 @@ _But ever wondered how an RTree is actually implemented?_
 
 In this post we'll dive into the implementation of Flatbush, a blazing-fast, memory-efficient RTree.
 
-Because the post uses a different theme, it is hosted _directly_ by Github pages at ([https://kylebarron.dev/literate-flatbush/](https://kylebarron.dev/literate-flatbush/)), and embedded below:
+Because the post uses a different theme, it is hosted _directly_ by Github pages at (<a href="https://kylebarron.dev/literate-flatbush/">https://kylebarron.dev/literate-flatbush/</a>), and embedded below:
 
 <iframe
   width="100%"

--- a/content/posts/literate-flatbush.mdx
+++ b/content/posts/literate-flatbush.mdx
@@ -11,6 +11,7 @@ _But ever wondered how an RTree is actually implemented?_
 
 In this post we'll dive into the implementation of Flatbush, a blazing-fast, memory-efficient RTree.
 
+{/* Note: We use a raw HTML link so that gatsby doesn't intercept the link */}
 Because the post uses a different theme, it is hosted _directly_ by Github pages at (<a href="https://kylebarron.dev/literate-flatbush/">https://kylebarron.dev/literate-flatbush/</a>), and embedded below:
 
 <iframe


### PR DESCRIPTION
We use a raw HTML link so that gatsby doesn't intercept the link