### PR TITLE
Improved code block styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This site started from the [`gatsby-starter-minimal-blog`](https://www.gatsbyjs.
 Gatsby theme. This means that the default style can be overridden bit by bit by
 _shadowing_ (overwriting) individual files from the theme.
 
+## Notes to self
+
+- Code highlighting settings exist in `code.ts`. To add more languages, add more settings there. That's for the little language tab that appears at the top left of code blocks.
+
 ## Theme Features
 
 - MDX
@@ -51,13 +55,13 @@ yarn
 # start hot-reloading server
 gatsby develop
 ```
-After `gatsby develop`, the site is now running by default on `http://localhost:8000`. 
+After `gatsby develop`, the site is now running by default on `http://localhost:8000`.
 
 ### Modifying the theme
 
 The base theme is installed as an NPM dependency. To overwrite parts of the theme, you use Gatsby _shadowing_ (Guide: [Shadowing in Gatsby Themes](https://www.gatsbyjs.org/docs/themes/shadowing/)).
 
-To overwrite parts of the theme, add files in this repository at 
+To overwrite parts of the theme, add files in this repository at
 ```
 src/@lekoarts/gatsby-theme-minimal-blog/
 ```

--- a/src/@lekoarts/gatsby-theme-minimal-blog/styles/code.ts
+++ b/src/@lekoarts/gatsby-theme-minimal-blog/styles/code.ts
@@ -80,15 +80,83 @@ const code = {
       textTransform: `uppercase`,
       top: 0,
     },
-    'pre[class~="language-javascript"]:before, pre[class~="language-js"]:before': {
-      content: `"js"`,
-      background: `#f7df1e`,
+    "pre[class~='language-bash']:before": {
+      content: `'bash'`,
+    },
+    'pre[class~="language-cpp"]:before': {
+      content: `"C++"`,
+      background: `#f34b7d`,
+      color: `white`,
+    },
+    'pre[class~="language-css"]:before': {
+      content: `"css"`,
+      background: `#ff9800`,
       color: `black`,
+    },
+    "pre[class~='language-diff']:before": {
+      content: `'diff'`,
+      background: `#e6ffed`,
+    },
+    'pre[class~="language-graphql"]:before': {
+      content: `"GraphQL"`,
+      background: `#E10098`,
+    },
+    'pre[class~="language-html"]:before': {
+      content: `"html"`,
+      background: `#005a9c`,
+      color: `white`,
+    },
+    'pre[class~="language-javascript"]:before, pre[class~="language-js"]:before':
+      {
+        content: `"js"`,
+        background: `#f7df1e`,
+        color: `black`,
+      },
+    "pre[class~='language-json']:before, pre[class~='language-json5']:before": {
+      content: `'json'`,
+      background: `linen`,
     },
     'pre[class~="language-jsx"]:before': {
       content: `"jsx"`,
       background: `#61dafb`,
       color: `black`,
+    },
+    "pre[class~='language-markdown']:before": {
+      content: `'md'`,
+    },
+    'pre[class~="language-mdx"]:before': {
+      content: `"mdx"`,
+      background: `#f9ac00`,
+      color: `black`,
+    },
+    'pre[class~="language-python"]:before, pre[class~="language-py"]:before': {
+      content: `"Python"`,
+      background: `#3572A5`,
+      color: `white`,
+    },
+    'pre[class~="language-rust"]:before, pre[class~="language-rs"]:before': {
+      content: `"rust"`,
+      background: `#dea584`,
+      color: `black`,
+    },
+    "pre[class~='language-sh']:before": {
+      content: `'sh'`,
+    },
+    "pre[class~='language-shell']:before": {
+      content: `'shell'`,
+    },
+    'pre[class~="language-sql"]:before': {
+      content: `"SQL"`,
+      background: `#e38c00`,
+      color: `black`,
+    },
+    'pre[class~="language-svg"]:before': {
+      content: `"svg"`,
+      background: `#005a9c`,
+      color: `white`,
+    },
+    'pre[class~="language-text"]:before': {
+      content: `"text"`,
     },
     'pre[class~="language-ts"]:before': {
       content: `"ts"`,
@@ -100,46 +168,10 @@ const code = {
       background: `#61dafb`,
       color: `black`,
     },
-    'pre[class~="language-html"]:before': {
-      content: `"html"`,
-      background: `#005a9c`,
-      color: `white`,
-    },
     'pre[class~="language-xml"]:before': {
       content: `"xml"`,
       background: `#005a9c`,
       color: `white`,
-    },
-    'pre[class~="language-svg"]:before': {
-      content: `"svg"`,
-      background: `#005a9c`,
-      color: `white`,
-    },
-    'pre[class~="language-graphql"]:before': {
-      content: `"GraphQL"`,
-      background: `#E10098`,
-    },
-    'pre[class~="language-css"]:before': {
-      content: `"css"`,
-      background: `#ff9800`,
-      color: `black`,
-    },
-    'pre[class~="language-mdx"]:before': {
-      content: `"mdx"`,
-      background: `#f9ac00`,
-      color: `black`,
-    },
-    'pre[class~="language-text"]:before': {
-      content: `"text"`,
-    },
-    "pre[class~='language-shell']:before": {
-      content: `'shell'`,
-    },
-    "pre[class~='language-sh']:before": {
-      content: `'sh'`,
-    },
-    "pre[class~='language-bash']:before": {
-      content: `'bash'`,
     },
     "pre[class~='language-yaml']:before": {
       content: `'yaml'`,
@@ -149,26 +181,16 @@ const code = {
       content: `'yml'`,
       background: `#ffa8df`,
     },
-    "pre[class~='language-markdown']:before": {
-      content: `'md'`,
-    },
-    "pre[class~='language-json']:before, pre[class~='language-json5']:before": {
-      content: `'json'`,
-      background: `linen`,
-    },
-    "pre[class~='language-diff']:before": {
-      content: `'diff'`,
-      background: `#e6ffed`,
-    },
   },
-  '.gatsby-highlight > code[class*="language-"], .gatsby-highlight > pre[class=*="language-"]': {
-    wordSpacing: `normal`,
-    wordBreak: `normal`,
-    overflowWrap: `normal`,
-    lineHeight: 1.5,
-    tabSize: 4,
-    hyphens: `none`,
-  },
+  '.gatsby-highlight > code[class*="language-"], .gatsby-highlight > pre[class=*="language-"]':
+    {
+      wordSpacing: `normal`,
+      wordBreak: `normal`,
+      overflowWrap: `normal`,
+      lineHeight: 1.5,
+      tabSize: 4,
+      hyphens: `none`,
+    },
   ".line-number-style": {
     display: `inline-block`,
     width: `3em`,


### PR DESCRIPTION
Previously the code blocks were always dark:

<img width="1042" height="845" alt="image" src="https://github.com/user-attachments/assets/1f5e166f-adca-480d-96fe-e6999ee57617" />

(so bad)

That now looks like:

<img width="1052" height="663" alt="image" src="https://github.com/user-attachments/assets/1b44a336-4daa-4086-8cab-baf93d2fd7ea" />

Still no syntax highlighting but an improvement.

<img width="415" height="214" alt="image" src="https://github.com/user-attachments/assets/c3f5ac15-06b7-4e9f-90f9-059c2fb5efab" />

Also added this little tab for more languages (and alphabetized that list)